### PR TITLE
Update license info in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-banner": "^0.6.0",


### PR DESCRIPTION
I am trying to add your library into cdnjs. It seems that this library is using a MIT license, which does not correspond to the information in the package.json. So I request for this change to update the field in license from "ISC" to "MIT".