### PR TITLE
Include SASS source files in published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,7 +3,6 @@ node_modules
 bower_components
 test
 tests
-src
 js
 img
 fonts


### PR DESCRIPTION
I had the same need as issue #64, which is to include modify the $mockup-path variable in the SASS files. This is because I'm including the files in my own webpack build and the variable is relative to my main file and not the packaged CSS file.

This PR simply adds the src folder in the npm bundle, in addition to the existing dist folder. It will require a new npm package to be published first to see the changes.